### PR TITLE
Bumped gulp-less to ~3.0.x version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-jscs": "~1.4.0",
     "gulp-jshint": "~1.9.0",
     "gulp-karma": "~0.0.4",
-    "gulp-less": "~2.0.x",
+    "gulp-less": "~3.0.x",
     "gulp-livereload": "~3.4.x",
     "gulp-merge": "~0.1.0",
     "gulp-minify-css": "~0.3.11",


### PR DESCRIPTION
Hey,
I have installed node 0.12.2 in my dev environment and gulp-less 2.x is not compatible with io and node 0.12.

When I'm trying to run gulp,  I get

```
[23:23:34] Finished 'copySupport' after 4.3 ms
./ProtractorExample/node_modules/gulp-less/index.js:68
    }).done(undefined, cb);
       ^
TypeError: undefined is not a function
    at DestroyableTransform._transform (./ProtractorExample/node_modules/gulp-less/index.js:68:8)
    at DestroyableTransform.Transform._read (./ProtractorExample/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (./ProtractorExample/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (./ProtractorExample/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (./ProtractorExample/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (./ProtractorExample/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (./ProtractorExample/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (./ProtractorExample/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (./ProtractorExample/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
    at DestroyableTransform.emit (events.js:104:17)
```

Next major version `3.x` is compatible with node 0.12 and fix this issue :)
More details are available in gulp-less repo - https://github.com/plus3network/gulp-less/issues/140
